### PR TITLE
Fix ranged value complications overlapping ring

### DIFF
--- a/android/watchface/src/main/java/android/support/wearable/complications/rendering/CustomComplicationRenderer.java
+++ b/android/watchface/src/main/java/android/support/wearable/complications/rendering/CustomComplicationRenderer.java
@@ -481,8 +481,12 @@ public class CustomComplicationRenderer extends ComplicationRenderer {
                 this.mMainTextRenderer.setRelativePadding(paddingAmount / (float)this.mMainTextBounds.width(), 0.0F, 0.0F, 0.0F);
                 this.mSubTextRenderer.setRelativePadding(paddingAmount / (float)this.mMainTextBounds.width(), 0.0F, 0.0F, 0.0F);
             } else {
-                this.mMainTextRenderer.setRelativePadding(0.0F, 0.0F, 0.0F, 0.0F);
-                this.mSubTextRenderer.setRelativePadding(0.0F, 0.0F, 0.0F, 0.0F);
+                float horizontalPadding = 0f;
+                if (this.mComplicationData.getType() == TYPE_RANGED_VALUE) {
+                    horizontalPadding = 0.12f;
+                }
+                this.mMainTextRenderer.setRelativePadding(horizontalPadding, 0.0F, horizontalPadding, 0.0F);
+                this.mSubTextRenderer.setRelativePadding(horizontalPadding, 0.0F, horizontalPadding, 0.0F);
             }
 
             Rect innerBounds = new Rect();


### PR DESCRIPTION
Hi, Benoit! Here's the fix I promised earlier!

I've tested it on two emulators (xhdpi and hdpi) and my Fossil Gen 5 watch. They all looked good.
I got the `1.2f` magic constant after some trial and error 🙂 
But some other values might look good too. I'll let you decide based on some animated screenshots I created. They show values ranging `0.08f`..`0.16f`. `0f` padding is equivalent to the state before the fix. Please feel free to change the `horizontalPadding` value in my code.

Take a look at the upper right complication:

hdpi:
![Screenshot_1621591811-ANIMATION_hdpi](https://user-images.githubusercontent.com/1349654/119205194-dc131c00-ba97-11eb-997a-15035d8aa21d.gif)

xhdpi:
![Screenshot_1621591809-ANIMATION_xhdpi](https://user-images.githubusercontent.com/1349654/119205190-d9182b80-ba97-11eb-8279-f995022bb579.gif)

I know, this fix is a bit hacky, sorry about that.
But I hope you like the end result 😄

Fixes benoitletondor/PixelMinimalWatchFace#4