### PR TITLE
Remove circle around complications in ambient mode

### DIFF
--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/regular/RegularDigitalWatchFaceDrawer.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/regular/RegularDigitalWatchFaceDrawer.kt
@@ -130,8 +130,8 @@ class RegularDigitalWatchFaceDrawer(
 
             if( complicationId == PixelMinimalWatchFace.BOTTOM_COMPLICATION_ID) {
                 complicationDrawable.setBorderColorActive(ContextCompat.getColor(context, R.color.transparent))
-                complicationDrawable.setBorderColorAmbient(ContextCompat.getColor(context, R.color.transparent))
             }
+            complicationDrawable.setBorderColorAmbient(ContextCompat.getColor(context, R.color.transparent))
 
             onComplicationDataUpdate(complicationId, complicationsData[complicationId], complicationColors)
         }


### PR DESCRIPTION
Small change to remove unnecessary circle around complications when in ambient mode.
I've been using the app with this change for a while now, and it works fine for me.
I don't know if this issue affects `Android12DigitalWatchFaceDrawer`, I only focued on `RegularDigitalWatchFaceDrawer`

Fixes #17 