### PR TITLE
Use the thin time style in regular mode

### DIFF
--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/android12/Android12DigitalWatchFaceDrawer.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/android12/Android12DigitalWatchFaceDrawer.kt
@@ -287,6 +287,7 @@ class Android12DigitalWatchFaceDrawer(
         timePaint.apply {
             isAntiAlias = !(ambient && lowBitAmbient)
             color = if( ambient ) { timeColorDimmed } else { storage.getTimeAndDateColor() }
+            style = if (storage.shouldShowThinTimeRegular() && !ambient) { Paint.Style.STROKE } else { Paint.Style.FILL } // excluding ambient here, since it works different for the A12 theme
             typeface = if( ambient && !storage.shouldShowFilledTimeInAmbientMode() ) { productSansThinFont } else { productSansRegularFont }
         }
 

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/regular/RegularDigitalWatchFaceDrawer.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/regular/RegularDigitalWatchFaceDrawer.kt
@@ -32,7 +32,6 @@ import com.benoitletondor.pixelminimalwatchface.PhoneBatteryStatus
 import com.benoitletondor.pixelminimalwatchface.PixelMinimalWatchFace
 import com.benoitletondor.pixelminimalwatchface.R
 import com.benoitletondor.pixelminimalwatchface.drawer.WatchFaceDrawer
-import com.benoitletondor.pixelminimalwatchface.drawer.digital.android12.Android12DigitalWatchFaceDrawer
 import com.benoitletondor.pixelminimalwatchface.helper.*
 import com.benoitletondor.pixelminimalwatchface.model.ComplicationColors
 import com.benoitletondor.pixelminimalwatchface.model.Storage
@@ -491,7 +490,7 @@ class RegularDigitalWatchFaceDrawer(
 
         timePaint.apply {
             isAntiAlias = !(ambient && lowBitAmbient)
-            style = if( ambient && !storage.shouldShowFilledTimeInAmbientMode() ) { Paint.Style.STROKE } else { Paint.Style.FILL }
+            style = if( ambient && !storage.shouldShowFilledTimeInAmbientMode() || storage.shouldShowThinTimeRegular() && !ambient) { Paint.Style.STROKE } else { Paint.Style.FILL }
             color = if( ambient ) { timeColorDimmed } else { storage.getTimeAndDateColor() }
         }
 

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/model/Storage.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/model/Storage.kt
@@ -45,6 +45,7 @@ private const val KEY_APP_VERSION = "appVersion"
 private const val KEY_SHOW_WEAR_OS_LOGO = "showWearOSLogo"
 private const val KEY_SHOW_COMPLICATIONS_AMBIENT = "showComplicationsAmbient"
 private const val KEY_FILLED_TIME_AMBIENT = "filledTimeAmbient"
+private const val KEY_THIN_TIME_REGULAR = "thinTimeRegularMode"
 private const val KEY_TIME_SIZE = "timeSize"
 private const val KEY_DATE_AND_BATTERY_SIZE = "dateSize"
 private const val KEY_SECONDS_RING = "secondsRing"
@@ -79,6 +80,8 @@ interface Storage {
     fun setShouldShowComplicationsInAmbientMode(show: Boolean)
     fun shouldShowFilledTimeInAmbientMode(): Boolean
     fun setShouldShowFilledTimeInAmbientMode(showFilledTime: Boolean)
+    fun shouldShowThinTimeRegular(): Boolean
+    fun setShouldShowThinTimeRegular(showThinTimeRegular: Boolean)
     fun getTimeSize(): Int
     fun setTimeSize(timeSize: Int)
     fun getDateAndBatterySize(): Int
@@ -389,6 +392,14 @@ class StorageImpl : Storage {
 
     override fun setShouldShowFilledTimeInAmbientMode(showFilledTime: Boolean) {
         sharedPreferences.edit().putBoolean(KEY_FILLED_TIME_AMBIENT, showFilledTime).apply()
+    }
+
+    override fun shouldShowThinTimeRegular(): Boolean {
+        return sharedPreferences.getBoolean(KEY_THIN_TIME_REGULAR, false)
+    }
+
+    override fun setShouldShowThinTimeRegular(showThinTimeRegular: Boolean) {
+        sharedPreferences.edit().putBoolean(KEY_THIN_TIME_REGULAR, showThinTimeRegular).apply()
     }
 
     override fun getTimeSize(): Int {

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/settings/SettingsActivity.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/settings/SettingsActivity.kt
@@ -63,6 +63,8 @@ class SettingsActivity : Activity() {
             storage.setShouldShowComplicationsInAmbientMode(showComplicationsAmbient)
         }, { showFilledTimeAmbient ->
             storage.setShouldShowFilledTimeInAmbientMode(showFilledTimeAmbient)
+        }, { showThinTimeRegular ->
+            storage.setShouldShowThinTimeRegular(showThinTimeRegular)
         }, { timeSize ->
             storage.setTimeSize(timeSize)
         }, { dateAndBatterySize ->

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/settings/SettingsRecyclerViewAdapter.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/settings/SettingsRecyclerViewAdapter.kt
@@ -27,6 +27,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.benoitletondor.pixelminimalwatchface.*
 import com.benoitletondor.pixelminimalwatchface.PixelMinimalWatchFace.Companion.getComplicationId
+import com.benoitletondor.pixelminimalwatchface.databinding.ConfigListShowThinTimeRegularBinding
 import com.benoitletondor.pixelminimalwatchface.drawer.digital.android12.Android12DigitalWatchFaceDrawer
 import com.benoitletondor.pixelminimalwatchface.drawer.digital.regular.RegularDigitalWatchFaceDrawer
 import com.benoitletondor.pixelminimalwatchface.helper.isPermissionGranted
@@ -46,6 +47,7 @@ private const val TYPE_SEND_FEEDBACK = 6
 private const val TYPE_SHOW_WEAR_OS_LOGO = 7
 private const val TYPE_SHOW_COMPLICATIONS_AMBIENT = 8
 private const val TYPE_SHOW_FILLED_TIME_AMBIENT = 9
+private const val TYPE_SHOW_THIN_TIME_REGULAR = 32
 private const val TYPE_TIME_SIZE = 10
 private const val TYPE_SHOW_SECONDS_RING = 11
 private const val TYPE_SHOW_WEATHER = 12
@@ -78,6 +80,7 @@ class ComplicationConfigRecyclerViewAdapter(
     private val showWearOSButtonListener: (Boolean) -> Unit,
     private val showComplicationsAmbientListener: (Boolean) -> Unit,
     private val showFilledTimeAmbientListener: (Boolean) -> Unit,
+    private val showThinTimeRegularListener: (Boolean) -> Unit,
     private val timeSizeChangedListener: (Int) -> Unit,
     private val dateAndBatterySizeChangedListener: (Int) -> Unit,
     private val showSecondsRingListener: (Boolean) -> Unit,
@@ -165,6 +168,14 @@ class ComplicationConfigRecyclerViewAdapter(
                     false
                 ),
                 hourFormatSelectionListener
+            )
+            TYPE_SHOW_THIN_TIME_REGULAR -> return ThinTimeRegularViewHolder(
+                LayoutInflater.from(parent.context).inflate(
+                    R.layout.config_list_show_thin_time_regular,
+                    parent,
+                    false
+                ),
+                showThinTimeRegularListener
             )
             TYPE_SEND_FEEDBACK -> return SendFeedbackViewHolder(
                 LayoutInflater.from(parent.context).inflate(
@@ -401,6 +412,10 @@ class ComplicationConfigRecyclerViewAdapter(
                 val use24hTimeFormat = storage.getUse24hTimeFormat()
                 (viewHolder as HourFormatViewHolder).setHourFormatSwitchChecked(use24hTimeFormat)
             }
+            TYPE_SHOW_THIN_TIME_REGULAR -> {
+                val useThinTimeInRegular = storage.shouldShowThinTimeRegular()
+                (viewHolder as ThinTimeRegularViewHolder).setShowThinTimeRegularSwitchChecked(useThinTimeInRegular)
+            }
             TYPE_SHOW_WEAR_OS_LOGO -> {
                 (viewHolder as ShowWearOSLogoViewHolder).apply {
                     setShowWearOSLogoSwitchChecked(storage.shouldShowWearOSLogo())
@@ -588,6 +603,7 @@ class ComplicationConfigRecyclerViewAdapter(
             list.add(TYPE_SHOW_WEATHER)
         }
         list.add(TYPE_HOUR_FORMAT)
+        list.add(TYPE_SHOW_THIN_TIME_REGULAR)
         list.add(TYPE_TIME_SIZE)
         list.add(TYPE_DATE_AND_BATTERY_SIZE)
         list.add(TYPE_TIME_AND_DATE_COLOR)

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/settings/SettingsRecyclerViewViewHolders.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/settings/SettingsRecyclerViewViewHolders.kt
@@ -335,6 +335,24 @@ class HourFormatViewHolder(
     }
 }
 
+
+class ThinTimeRegularViewHolder(
+    view: View,
+    showThinTimeRegularListener: (Boolean) -> Unit,
+) : RecyclerView.ViewHolder(view) {
+    private val showThinTimeRegularSwitch: Switch = view as Switch
+
+    init {
+        showThinTimeRegularSwitch.setOnCheckedChangeListener { _, checked ->
+            showThinTimeRegularListener(checked)
+        }
+    }
+
+    fun setShowThinTimeRegularSwitchChecked(checked: Boolean) {
+        showThinTimeRegularSwitch.isChecked = checked
+    }
+}
+
 class ShowWearOSLogoViewHolder(
     view: View,
     showWearOSLogoClickListener: (Boolean) -> Unit,

--- a/android/watchface/src/main/res/layout/config_list_show_thin_time_regular.xml
+++ b/android/watchface/src/main/res/layout/config_list_show_thin_time_regular.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Copyright 2021 Benoit LETONDOR
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<Switch
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/config_list_show_thin_time_regular_switch"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    style="@style/ButtonConfigurationStyle"
+    android:text="@string/config_show_thin_time_regular"
+    android:drawableStart="@drawable/ic_baseline_invert_colors"/>

--- a/android/watchface/src/main/res/values/strings.xml
+++ b/android/watchface/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="config_show_wear_os_logo">Show WearOS logo</string>
     <string name="config_show_weather">Show weather after date</string>
     <string name="config_show_filled_time_ambient">Use thin time in ambient mode</string>
+    <string name="config_show_thin_time_regular">Use thin time in regular mode</string>
     <string name="config_show_wear_os_logo_premium">WearOS logo as middle widget</string>
     <string name="config_show_complications_ambient">Widgets in ambient mode</string>
     <string name="config_time_size">Size of time: %s</string>


### PR DESCRIPTION
Added a minor feature, which allows the usage of the thin, outlined time in regular mode. By default this setting is turned off and the switch is located at the Time and Date settings.

Please feel free to review my changes, as I'm quiet new to Kotlin and Android/Wear OS development. 


Keep up the good work, I enjoy using your Watchface a lot!