### PR TITLE
Allow selecting between sweeping and ticking seconds motion

### DIFF
--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/PixelMinimalWatchFace.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/PixelMinimalWatchFace.kt
@@ -792,7 +792,7 @@ class PixelMinimalWatchFace : CanvasWatchFaceService() {
         @Suppress("SameParameterValue")
         private fun getNextComplicationUpdateDelay(): Long? {
             if( storage.showSecondsRing() ) {
-                return 1000
+                return if (storage.useSweepingSecondsMotion()) 50 else 1000
             }
 
             var minValue = Long.MAX_VALUE

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/SecondsRingDrawer.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/SecondsRingDrawer.kt
@@ -24,6 +24,7 @@ interface SecondsRingDrawer {
         canvas: Canvas,
         calendar: Calendar,
         paint: Paint,
+        useSweepingMotion: Boolean
     )
 }
 
@@ -35,8 +36,23 @@ class SecondRingDrawerImpl(
         canvas: Canvas,
         calendar: Calendar,
         paint: Paint,
+        useSweepingMotion: Boolean
     ) {
-        val endAngle = (calendar.get(Calendar.SECOND) * 6).toFloat()
+        val endAngle = calculateEndAngle(useSweepingMotion, calendar)
         canvas.drawArc(0F, 0F, screenWidth.toFloat(), screenHeight.toFloat(), 270F, endAngle, false, paint)
+    }
+
+    private fun calculateEndAngle(useSweepingMotion: Boolean, calendar: Calendar) = if (useSweepingMotion) {
+        calculateSweepingEndRotation(calendar)
+    } else {
+        calculateTickingEndRotation(calendar)
+    }
+
+    private fun calculateTickingEndRotation(calendar: Calendar) = (calendar.get(Calendar.SECOND) * 6).toFloat()
+
+    private fun calculateSweepingEndRotation(calendar: Calendar): Float {
+        val epochMillisOfDay = calendar.timeInMillis
+        val millisPerSecondRingRotation = 1000 * 60
+        return epochMillisOfDay.rem(millisPerSecondRingRotation) * 360.0f / millisPerSecondRingRotation
     }
 }

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/android12/Android12DigitalWatchFaceDrawer.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/android12/Android12DigitalWatchFaceDrawer.kt
@@ -276,6 +276,7 @@ class Android12DigitalWatchFaceDrawer(
                 ambient,
                 storage.isUserPremium(),
                 storage.showSecondsRing(),
+                storage.useSweepingSecondsMotion(),
                 storage.showWatchBattery(),
                 storage.showPhoneBattery(),
                 !ambient || storage.getShowDateInAmbient(),
@@ -497,6 +498,7 @@ class Android12DigitalWatchFaceDrawer(
         ambient:Boolean,
         isUserPremium: Boolean,
         drawSecondsRing: Boolean,
+        useSweepingSecondsMotion: Boolean,
         drawBattery: Boolean,
         drawPhoneBattery: Boolean,
         drawDate: Boolean,
@@ -563,7 +565,7 @@ class Android12DigitalWatchFaceDrawer(
         }
 
         if( drawSecondsRing && !ambient ) {
-            drawSecondRing(canvas, calendar, secondsRingPaint)
+            drawSecondRing(canvas, calendar, secondsRingPaint, useSweepingSecondsMotion)
         }
 
         if( isUserPremium && (drawBattery || drawPhoneBattery) && (!ambient || !storage.hideBatteryInAmbient()) ) {

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/regular/RegularDigitalWatchFaceDrawer.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/drawer/digital/regular/RegularDigitalWatchFaceDrawer.kt
@@ -266,6 +266,7 @@ class RegularDigitalWatchFaceDrawer(
                 ambient,
                 storage.isUserPremium(),
                 storage.showSecondsRing(),
+                storage.useSweepingSecondsMotion(),
                 storage.showWatchBattery(),
                 storage.showPhoneBattery(),
                 !ambient || storage.getShowDateInAmbient(),
@@ -415,6 +416,7 @@ class RegularDigitalWatchFaceDrawer(
         ambient:Boolean,
         isUserPremium: Boolean,
         drawSecondsRing: Boolean,
+        useSweepingSecondsMotion: Boolean,
         drawBattery: Boolean,
         drawPhoneBattery: Boolean,
         drawDate: Boolean,
@@ -450,7 +452,7 @@ class RegularDigitalWatchFaceDrawer(
         }
 
         if( drawSecondsRing && !ambient ) {
-            drawSecondRing(canvas, calendar, secondsRingPaint)
+            drawSecondRing(canvas, calendar, secondsRingPaint, useSweepingSecondsMotion)
         }
 
         if( isUserPremium && (drawBattery || drawPhoneBattery) && (!ambient || !storage.hideBatteryInAmbient()) ) {

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/model/Storage.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/model/Storage.kt
@@ -51,6 +51,7 @@ private const val KEY_USE_THIN_TIME_STYLE_IN_REGULAR = "thinTimeRegularMode"
 private const val KEY_TIME_SIZE = "timeSize"
 private const val KEY_DATE_AND_BATTERY_SIZE = "dateSize"
 private const val KEY_SECONDS_RING = "secondsRing"
+private const val KEY_USE_SWEEPING_SECONDS_MOTION = "useSweepingSecondsMotion"
 private const val KEY_SHOW_WEATHER = "showWeather"
 private const val KEY_SHOW_WATCH_BATTERY = "showBattery"
 private const val KEY_SHOW_PHONE_BATTERY = "showPhoneBattery"
@@ -109,6 +110,9 @@ interface Storage {
     fun showSecondsRing(): Boolean
     fun setShowSecondsRing(showSecondsRing: Boolean)
     fun watchShowSecondsRing(): Flow<Boolean>
+    fun useSweepingSecondsMotion(): Boolean
+    fun setUseSweepingSecondsMotion(useSweepingSecondsMotion: Boolean)
+    fun watchUseSweepingSecondsMotion(): Flow<Boolean>
     fun showWeather(): Boolean
     fun setShowWeather(show: Boolean)
     fun watchShowWeather(): Flow<Boolean>
@@ -178,6 +182,7 @@ class StorageImpl(
     private val showComplicationsInAmbientModeCache = StorageCachedBoolValue(sharedPreferences, KEY_SHOW_COMPLICATIONS_AMBIENT, false)
     private val showColorsInAmbientModeCache = StorageCachedBoolValue(sharedPreferences, KEY_SHOW_COLORS_AMBIENT, false)
     private val showSecondsRingCache = StorageCachedBoolValue(sharedPreferences, KEY_SECONDS_RING, false)
+    private val useSweepingSecondsMotionCache = StorageCachedBoolValue(sharedPreferences, KEY_USE_SWEEPING_SECONDS_MOTION, false)
     private val showWeatherCache = StorageCachedBoolValue(sharedPreferences, KEY_SHOW_WEATHER, false)
     private val showWatchBattery = StorageCachedBoolValue(sharedPreferences, KEY_SHOW_WATCH_BATTERY, false)
     private val useShortDateFormatCache = StorageCachedBoolValue(sharedPreferences, KEY_USE_SHORT_DATE_FORMAT, false)
@@ -399,6 +404,16 @@ class StorageImpl(
     override fun setShowSecondsRing(showSecondsRing: Boolean) = showSecondsRingCache.set(showSecondsRing)
 
     override fun watchShowSecondsRing(): Flow<Boolean> = showSecondsRingCache.watchChanges()
+
+    override fun useSweepingSecondsMotion() = useSweepingSecondsMotionCache.get()
+
+    override fun setUseSweepingSecondsMotion(useSweepingSecondsMotion: Boolean) {
+        useSweepingSecondsMotionCache.set(useSweepingSecondsMotion)
+    }
+
+    override fun watchUseSweepingSecondsMotion(): Flow<Boolean> {
+        return useSweepingSecondsMotionCache.watchChanges()
+    }
 
     override fun showWeather(): Boolean = showWeatherCache.get()
 

--- a/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/settings/SettingsActivity.kt
+++ b/android/watchface/src/main/java/com/benoitletondor/pixelminimalwatchface/settings/SettingsActivity.kt
@@ -590,6 +590,7 @@ class SettingsActivity : ComponentActivity() {
         if( isScreenRound ) {
             item(key = "ShowSecondsRing") {
                 val showSecondsRing by storage.watchShowSecondsRing().collectAsState(storage.showSecondsRing())
+                val useSweepingSecondsMotion by storage.watchUseSweepingSecondsMotion().collectAsState(storage.useSweepingSecondsMotion())
 
                 Column {
                     SettingToggleChip(
@@ -613,6 +614,14 @@ class SettingsActivity : ComponentActivity() {
                             },
                             iconDrawable = R.drawable.ic_palette_24,
                             modifier = Modifier.padding(top = 4.dp),
+                        )
+
+                        SettingToggleChip(
+                            checked = useSweepingSecondsMotion,
+                            onCheckedChange = { storage.setUseSweepingSecondsMotion(it) },
+                            label = "Use Sweeping Motion",
+                            iconDrawable = R.drawable.ic_baseline_panorama_fish_eye,
+                            modifier = Modifier.padding(top = 4.dp)
                         )
                     }
                 }


### PR DESCRIPTION
## Summary 
Users can now change the seconds ring movement style to a Sweeping motion instead of the traditional Ticking motion.

Added a boolean value to storage and cache that tracks whether the user has opted to use the Sweeping motion instead of the default Ticking motion.

![pixel-watch-sweeping-seconds-ring](https://user-images.githubusercontent.com/1883101/202960131-e9b6570a-1064-4754-be1b-67a3f297dee5.gif)

![pixel-watch-sweeping-seconds-ring-option](https://user-images.githubusercontent.com/1883101/202960379-14fc9cae-7eec-4e3c-bc80-9eedce674f81.png)

Implements feature requested in Issue #26

## TODO
- [ ] Add icon drawable for sweeping seconds ring motion